### PR TITLE
Remove crypto dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "node-cron": "^3.0.3",
     "axios": "^1.6.2",
     "dotenv": "^16.3.1",
-    "crypto": "^1.0.1",
     "ws": "^8.14.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose
Fix dependency installation issues in the Kryonix platform installer. The user was experiencing critical missing dependencies errors when running the installer script on their Vultr server, which pulls dependencies from the main branch on GitHub. The goal is to ensure all dependencies can be properly resolved during the automated installation process.

## Code changes
- Removed the `crypto` dependency from package.json dependencies section
- The `crypto` module is a built-in Node.js module and doesn't need to be explicitly installed as an external dependency
- This resolves the missing dependency error that was preventing successful installation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/daacbc6974394e7692da6a3bc6a06886/pulse-hub)

👀 [Preview Link](https://daacbc6974394e7692da6a3bc6a06886-pulse-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>daacbc6974394e7692da6a3bc6a06886</projectId>-->
<!--<branchName>pulse-hub</branchName>-->