### PR TITLE
Redesign footer with social icons and remove dev badges

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -295,8 +295,7 @@ export default function HomePage() {
             </div>
             
             <div>
-              <h3 className="font-semibold mb-4">Contato</h3>
-              <div className="flex items-center space-x-4">
+              <div className="flex items-center justify-center space-x-4">
                 <a
                   href="https://wa.me/5517981805327?text=Olá! Gostaria de saber mais sobre a plataforma KRYONIX"
                   target="_blank"
@@ -306,6 +305,7 @@ export default function HomePage() {
                 >
                   <MessageCircle className="w-6 h-6" />
                 </a>
+                <span className="text-white font-semibold">Contato</span>
                 <a
                   href="mailto:contato@kryonix.com.br"
                   className="text-gray-400 hover:text-blue-500 transition-colors duration-200"

--- a/app/progresso/page.tsx
+++ b/app/progresso/page.tsx
@@ -226,8 +226,7 @@ export default function ProgressoPage() {
               </div>
               
               <div>
-                <h3 className="font-semibold mb-4">Contato</h3>
-                <div className="flex items-center space-x-4">
+                <div className="flex items-center justify-center space-x-4">
                   <a
                     href="https://wa.me/5517981805327?text=Olá! Gostaria de saber mais sobre a plataforma KRYONIX"
                     target="_blank"
@@ -237,6 +236,7 @@ export default function ProgressoPage() {
                   >
                     <MessageCircle className="w-6 h-6" />
                   </a>
+                  <span className="text-white font-semibold">Contato</span>
                   <a
                     href="mailto:contato@kryonix.com.br"
                     className="text-gray-400 hover:text-blue-500 transition-colors duration-200"


### PR DESCRIPTION
## Purpose

The user requested a complete footer redesign to improve the contact section and remove development status indicators. The main goals were to:
- Remove the "EM DESENVOLVIMENTO" badges from both home and progress pages
- Replace text-based contact information with clickable social media icons
- Create a horizontal layout with WhatsApp, Email, and Instagram icons
- Reduce footer padding and overall size
- Center the "Contato" text between the social icons

## Code changes

- **Removed development badges**: Eliminated the green status badges showing "EM DESENVOLVIMENTO - 53 PARTES PLANEJADAS" from both pages
- **Footer redesign**: Replaced text-based contact info with interactive social media icons
- **Icon implementation**: Added WhatsApp (MessageCircle), Email (Mail), and Instagram icons with proper hover effects and color transitions
- **Layout optimization**: Changed footer padding from `py-12` to `py-3` and grid gaps from `gap-8 mb-8` to `gap-2 mb-2`
- **Social links**: Implemented clickable links for WhatsApp (with pre-filled message), email (mailto), and Instagram
- **Responsive design**: Maintained horizontal icon layout with centered "Contato" label

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 45`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fc8ff433f5eb43a1a606846c70efbbbf/vibe-zone)

👀 [Preview Link](https://fc8ff433f5eb43a1a606846c70efbbbf-vibe-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fc8ff433f5eb43a1a606846c70efbbbf</projectId>-->
<!--<branchName>vibe-zone</branchName>-->