### PR TITLE
Add loading state and delayed mount for FilaDeEspera page

### DIFF
--- a/app/fila-de-espera/page.tsx
+++ b/app/fila-de-espera/page.tsx
@@ -65,7 +65,8 @@ export default function FilaDeEspera() {
   const [posicaoFila, setPosicaoFila] = useState<number | null>(null)
 
   useEffect(() => {
-    setMounted(true)
+    const timer = setTimeout(() => setMounted(true), 100)
+    return () => clearTimeout(timer)
   }, [])
 
   const segmentosNegocio = [
@@ -285,7 +286,14 @@ export default function FilaDeEspera() {
   }
 
   if (!mounted) {
-    return null
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-green-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 flex items-center justify-center">
+        <div className="animate-pulse text-center">
+          <div className="w-12 h-12 bg-blue-600 rounded-lg mx-auto mb-4"></div>
+          <div className="text-lg text-gray-600 dark:text-gray-300">Carregando...</div>
+        </div>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Changes Made

### Component Mounting
- Modified the `useEffect` hook to delay the `setMounted(true)` call by 100ms using `setTimeout`
- Added proper cleanup function to clear the timeout when component unmounts

### Loading State UI
- Replaced the `return null` statement with a comprehensive loading screen
- Added gradient background matching the main page design (blue-50 to green-50 in light mode, gray-900 to gray-700 in dark mode)
- Implemented centered loading indicator with:
  - Animated pulse effect
  - Blue rounded square icon (12x12)
  - "Carregando..." text with appropriate dark mode styling

### Layout Improvements
- Loading state now uses full viewport height (`min-h-screen`)
- Flexbox centering for proper alignment of loading content

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fe88b26e3926438e87d1b89edecb7d30/zen-haven)

👀 [Preview Link](https://fe88b26e3926438e87d1b89edecb7d30-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe88b26e3926438e87d1b89edecb7d30</projectId>-->
<!--<branchName>zen-haven</branchName>-->